### PR TITLE
Fix getting the download URL in install-binary.sh

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -30,7 +30,7 @@ initArch() {
 
 # initOS discovers the operating system for this system.
 initOS() {
-  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+  OS=$(echo `uname`)
 
   case "$OS" in
     # Minimalist GNU for Windows


### PR DESCRIPTION
Since the new releases tarballs now use capitalized names for OSes it is no longer needed to lowercase the OS names in initOS function. This patch fixes the issue that causes every installation to fail.

Fixes https://github.com/halkeye/helm-repo-html/issues/5