### PR TITLE
Don't escape quotation marks in awk

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -52,9 +52,9 @@ getDownloadURL() {
   # Use the GitHub API to find the latest version for this project.
   local latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
   if type "curl" > /dev/null; then
-    DOWNLOAD_URL=$(curl -s $latest_url | grep $OS | grep $ARCH | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
+    DOWNLOAD_URL=$(curl -s $latest_url | grep $OS | grep $ARCH | awk '/"browser_download_url":/{gsub( /[,"]/,"", $2); print $2}')
   elif type "wget" > /dev/null; then
-    DOWNLOAD_URL=$(wget -q -O - $latest_url | grep $OS | grep $ARCH | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
+    DOWNLOAD_URL=$(wget -q -O - $latest_url | grep $OS | grep $ARCH | awk '/"browser_download_url":/{gsub( /[,"]/,"", $2); print $2}')
   fi
 }
 


### PR DESCRIPTION
Installing the helm-repo-html as [GitHub action](https://github.com/suse-edge/dashboard-extensions/actions/runs/6968244079/job/18961822924) fails with:
```
Run helm plugin list | grep -q repo-html || helm plugin install https://github.com/halkeye/helm-repo-html
awk: cmd. line:1: warning: regexp escape sequence `\"' is not a known regexp operator
```
Apparently the quotation marks in awk should not be escaped.